### PR TITLE
feat(container): more goodies

### DIFF
--- a/.github/workflows/ghcr_push_nightly.yml
+++ b/.github/workflows/ghcr_push_nightly.yml
@@ -1,0 +1,46 @@
+---
+name: Create and publish a Docker image
+
+on:
+    push:
+        branches: ['develop+ct']
+    # TODO: add timer based trigger here to push most recent builds.
+
+env:
+    REGISTRY: ghcr.io
+    IMAGE_TAG: nightly
+
+jobs:
+    build-and-push-image:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Set up JDK 11
+              uses: actions/setup-java@v2
+              with:
+                  java-version: 11
+                  distribution: 'adopt'
+            - name: Cache Maven packages
+              uses: actions/cache@v2
+              with:
+                  path: ~/.m2
+                  key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+                  restore-keys: ${{ runner.os }}-m2
+
+            - name: Build images
+              run: mvn -Pct package -Dct.build.tag="${IMAGE_TAG}" -Dct.build.registry="${REGISTRY}"
+
+            - name: Log in to the Container registry
+              uses: docker/login-action@v1
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Push Docker image
+              run: mvn -Pct docker:push -Dct.build.tag="${IMAGE_TAG}" -Dct.build.registry="${REGISTRY}"

--- a/conf/container/Dockerfile
+++ b/conf/container/Dockerfile
@@ -166,7 +166,10 @@ RUN true && \
     ${ASADMIN} create-system-properties jersey.config.client.connectTimeout="300000" && \
 
     ### DATAVERSE APPLICATION SPECIFICS
+    # Configure the MicroProfile directory config source to point to /secrets
     ${ASADMIN} set-config-dir --directory=${SECRETS_DIR} && \
+    # Make request timeouts configurable via MPCONFIG (default to 900 secs = 15 min)
+    ${ASADMIN} set 'server-config.network-config.protocols.protocol.http-listener-1.http.request-timeout-seconds=${MPCONFIG=dataverse.http.timeout:900}' && \
     # TODO: what of the below 3 items can be deleted for container usage?
     ${ASADMIN} create-network-listener --protocol=http-listener-1 --listenerport=8009 --jkenabled=true jk-connector && \
     ${ASADMIN} set server-config.network-config.protocols.protocol.http-listener-1.http.comet-support-enabled=true && \

--- a/conf/container/Dockerfile
+++ b/conf/container/Dockerfile
@@ -19,7 +19,19 @@
 #  - Their image is less optimised for production usage by design choices
 #
 FROM openjdk:11-jre
-LABEL maintainer="FDM FZJ <forschungsdaten@fz-juelich.de>"
+
+LABEL org.opencontainers.image.created="@git.build.time@" \
+      org.opencontainers.image.authors="Research Data Management at FZJ <forschungsdaten@fz-juelich.de>" \
+      org.opencontainers.image.url="https://k8s-docs.gdcc.io" \
+      org.opencontainers.image.documentation="https://k8s-docs.gdcc.io" \
+      org.opencontainers.image.source="https://github.com/gdcc/dataverse/tree/develop%2Bct/conf/container" \
+      org.opencontainers.image.version="@project.version@" \
+      org.opencontainers.image.revision="@git.commit.id.abbrev@" \
+      org.opencontainers.image.vendor="Global Dataverse Community Consortium" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.title="dataverse-k8s :: Dataverse containerized" \
+      org.opencontainers.image.description="This container image provides the research data repository software Dataverse in a box."
+
 # Default payara ports to expose
 # 4848: admin console
 # 9009: debug port (JPDA)

--- a/conf/solr/Dockerfile
+++ b/conf/solr/Dockerfile
@@ -6,7 +6,17 @@
 
 FROM solr:@solr.version@
 
-LABEL maintainer="FDM FZJ <forschungsdaten@fz-juelich.de>"
+LABEL org.opencontainers.image.created="@git.build.time@" \
+      org.opencontainers.image.authors="Research Data Management at FZJ <forschungsdaten@fz-juelich.de>" \
+      org.opencontainers.image.url="https://k8s-docs.gdcc.io" \
+      org.opencontainers.image.documentation="https://k8s-docs.gdcc.io" \
+      org.opencontainers.image.source="https://github.com/gdcc/dataverse/tree/develop%2Bct/conf/solr" \
+      org.opencontainers.image.version="@project.version@" \
+      org.opencontainers.image.revision="@git.commit.id.abbrev@" \
+      org.opencontainers.image.vendor="Global Dataverse Community Consortium" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.title="solr-k8s :: Dataverse-ready Solr" \
+      org.opencontainers.image.description="This container image provides a Dataverse-ready Solr Search Index."
 
 ENV SOLR_OPTS="-Dsolr.jetty.request.header.size=102400" \
     COLLECTION="collection1" \

--- a/pom.xml
+++ b/pom.xml
@@ -906,9 +906,36 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>pl.project13.maven</groupId>
+                        <artifactId>git-commit-id-plugin</artifactId>
+                        <version>4.0.5</version>
+                        <executions>
+                            <execution>
+                                <id>get-the-git-infos</id>
+                                <goals>
+                                    <goal>revision</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <dateFormatTimeZone>UTC</dateFormatTimeZone>
+                            <abbrevLength>8</abbrevLength>
+                        </configuration>
+                    </plugin>
+                    <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
                         <version>0.36.1</version>
+                        <executions>
+                            <execution>
+                                <id>build-docker-images</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
                         <configuration>
                             <images>
                                 <!-- Dataverse K8s image -->

--- a/pom.xml
+++ b/pom.xml
@@ -894,10 +894,14 @@
             <id>ct</id>
             <properties>
                 <skipUnitTests>true</skipUnitTests>
+                <ct.build.registry>ghcr.io</ct.build.registry>
+                <ct.build.tag>${project.version}</ct.build.tag>
                 <ct.build.app.skip>false</ct.build.app.skip>
-                <ct.build.app.name>gdcc/dataverse-k8s:${project.version}</ct.build.app.name>
+                <ct.build.app.tag>${ct.build.tag}</ct.build.app.tag>
+                <ct.build.app.name>gdcc/dataverse-k8s:${ct.build.app.tag}</ct.build.app.name>
                 <ct.build.solr.skip>false</ct.build.solr.skip>
-                <ct.build.solr.name>gdcc/solr-k8s:${project.version}</ct.build.solr.name>
+                <ct.build.solr.tag>${ct.build.tag}</ct.build.solr.tag>
+                <ct.build.solr.name>gdcc/solr-k8s:${ct.build.solr.tag}</ct.build.solr.name>
                 <ct.run.jdwp>1</ct.run.jdwp>
                 <ct.run.jrebel>0</ct.run.jrebel>
                 <ct.run.db.user>dataverse</ct.run.db.user>
@@ -942,6 +946,7 @@
                                 <image>
                                     <alias>dataverse</alias>
                                     <name>${ct.build.app.name}</name>
+                                    <registry>${ct.build.registry}</registry>
                                     <build>
                                         <skip>${ct.build.app.skip}</skip>
                                         <dockerFile>${project.basedir}/conf/container/Dockerfile</dockerFile>
@@ -1000,6 +1005,7 @@
                                 <image>
                                     <alias>solr</alias>
                                     <name>${ct.build.solr.name}</name>
+                                    <registry>${ct.build.registry}</registry>
                                     <build>
                                         <skip>${ct.build.solr.skip}</skip>
                                         <dockerFile>${project.basedir}/conf/solr/Dockerfile</dockerFile>

--- a/pom.xml
+++ b/pom.xml
@@ -908,7 +908,7 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.36.0</version>
+                        <version>0.36.1</version>
                         <configuration>
                             <images>
                                 <!-- Dataverse K8s image -->


### PR DESCRIPTION
- [x] Tweak HTTP request timeout via env var / sys prop
- [x] Add labels gdcc/dataverse-kubernetes#223
- [ ] Add Github action to test build & deployment
- [x] Add Github action to push to container registry
- [ ] Pin apt packages (via [repology](https://docs.renovatebot.com/modules/datasource/#repology-datasource)), installs from Github (can't update SHA256) and base image digest, update with @renovatebot