### PR TITLE
Fix container image with Payara 5.2021.8+ and add integration testing feat

### DIFF
--- a/conf/container/Dockerfile
+++ b/conf/container/Dockerfile
@@ -18,7 +18,10 @@
 #  - Using same base image as Solr (https://hub.docker.com/_/solr) is reducing pulls
 #  - Their image is less optimised for production usage by design choices
 #
-FROM openjdk:11-jre
+
+# Make the Java base image and version configurable (useful for trying newer Java versions and flavors)
+ARG BASE_IMAGE="openjdk:11-jre"
+FROM $BASE_IMAGE
 
 # Default payara ports to expose
 # 4848: admin console

--- a/conf/container/Dockerfile
+++ b/conf/container/Dockerfile
@@ -77,15 +77,15 @@ WORKDIR /
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 RUN true && \
     # Create pathes
-    mkdir -p ${HOME_DIR} ${PAYARA_DIR} ${DEPLOY_DIR} ${CONFIG_DIR} ${SCRIPT_DIR} && \
-    mkdir -p ${DATA_DIR} ${METADATA_DIR} ${DOCROOT_DIR} ${SECRETS_DIR} ${DUMPS_DIR} && \
+    mkdir -p "${HOME_DIR}" "${PAYARA_DIR}" "${DEPLOY_DIR}" "${CONFIG_DIR}" "${SCRIPT_DIR}" && \
+    mkdir -p "${DATA_DIR}" "${METADATA_DIR}" "${DOCROOT_DIR}" "${SECRETS_DIR}" "${DUMPS_DIR}" && \
     # Create user
     addgroup --gid 1000 payara && \
     adduser --system --uid 1000 --no-create-home --shell /bin/bash --home "${HOME_DIR}" --gecos "" --ingroup payara payara && \
     echo payara:payara | chpasswd && \
     # Set permissions
-    chown -R payara: ${HOME_DIR} && \
-    chown -R payara: ${DATA_DIR} ${METADATA_DIR} ${DOCROOT_DIR} ${SECRETS_DIR} ${DUMPS_DIR}
+    chown -R payara: "${HOME_DIR}" && \
+    chown -R payara: "${DATA_DIR}" "${METADATA_DIR}" "${DOCROOT_DIR}" "${SECRETS_DIR}" "${DUMPS_DIR}"
 
 # Installing the packages in an extra container layer for better caching
 RUN true && \
@@ -94,21 +94,21 @@ RUN true && \
     apt-get install -qqy --no-install-recommends ${PKGS} && \
 
     # Download & check esh template script
-    curl -sSfL -o /usr/bin/esh https://raw.githubusercontent.com/jirutka/esh/v${ESH_VERSION}/esh && \
+    curl -sSfL -o /usr/bin/esh "https://raw.githubusercontent.com/jirutka/esh/v${ESH_VERSION}/esh" && \
     echo "${ESH_CHECKSUM} /usr/bin/esh" | sha256sum -c - && \
     chmod +x /usr/bin/esh && \
 
     # Install jattach
-    curl -sSfL -o /usr/bin/jattach https://github.com/apangin/jattach/releases/download/${JATTACH_VERSION}/jattach && \
+    curl -sSfL -o /usr/bin/jattach "https://github.com/apangin/jattach/releases/download/${JATTACH_VERSION}/jattach" && \
     echo "${JATTACH_CHECKSUM} /usr/bin/jattach" | sha256sum -c - && \
     chmod +x /usr/bin/jattach && \
 
     # Download & unzip JRebel to $JREBEL_LIB = ${HOME_DIR}/jrebel/lib/libjrebel64.so (for development use)
-    curl -sS -f -o ${HOME_DIR}/jrebel.zip http://dl.zeroturnaround.com/jrebel-stable-nosetup.zip && \
+    curl -sS -f -o "${HOME_DIR}/jrebel.zip" "http://dl.zeroturnaround.com/jrebel-stable-nosetup.zip" && \
     unzip -q "${HOME_DIR}/jrebel.zip" -d "${HOME_DIR}" && \
 
     # Cleanup
-    rm -rf /var/lib/apt/lists/* "${HOME_DIR}/jrebel.zip"
+    rm -rf "/var/lib/apt/lists/*" "${HOME_DIR}/jrebel.zip"
 
 ### PART 2: PAYARA ###
 # After setting up system, now configure Payara
@@ -121,7 +121,6 @@ COPY --chown=payara:payara maven/appserver ${PAYARA_DIR}/
 # Copy the system (appserver level) scripts like entrypoint, etc
 COPY --chown=payara:payara maven/scripts/system ${SCRIPT_DIR}/
 
-# TODO: refactor and make production ready
 # Configure the domain to be container and production ready
 RUN true && \
     # Set admin password
@@ -165,7 +164,7 @@ RUN true && \
 
     ### DATAVERSE APPLICATION SPECIFICS
     # Configure the MicroProfile directory config source to point to /secrets
-    ${ASADMIN} set-config-dir --directory=${SECRETS_DIR} && \
+    ${ASADMIN} set-config-dir --directory="${SECRETS_DIR}" && \
     # Make request timeouts configurable via MPCONFIG (default to 900 secs = 15 min)
     ${ASADMIN} set 'server-config.network-config.protocols.protocol.http-listener-1.http.request-timeout-seconds=${MPCONFIG=dataverse.http.timeout:900}' && \
     # TODO: what of the below 3 items can be deleted for container usage?
@@ -177,19 +176,19 @@ RUN true && \
 
     ### CLEANUP
     # Stop domain
-    ${ASADMIN} stop-domain ${DOMAIN_NAME} && \
+    ${ASADMIN} stop-domain "${DOMAIN_NAME}" && \
     # Delete generated files
     rm -rf \
-        /tmp/password-change-file.txt \
-        ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/osgi-cache \
-        ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/logs
+        "/tmp/password-change-file.txt" \
+        "${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/osgi-cache" \
+        "${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/logs"
 
 # Make docroot of Payara reside in higher level directory for easier targeting
 # Due to gdcc/dataverse-kubernetes#177: create the generated pathes so they are
 # writeable by us. TBR with gdcc/dataverse-kubernetes#178.
-RUN rm -rf ${DOMAIN_DIR}/docroot && \
-    ln -s ${DOCROOT_DIR} ${DOMAIN_DIR}/docroot && \
-    mkdir -p ${DOMAIN_DIR}/generated/jsp/dataverse
+RUN rm -rf "${DOMAIN_DIR}"/docroot && \
+    ln -s "${DOCROOT_DIR}" "${DOMAIN_DIR}"/docroot && \
+    mkdir -p "${DOMAIN_DIR}"/generated/jsp/dataverse
 
 ### PART 3: DATAVERSE INSTALLATION ###
 # Copy app and deps from assembly in proper layers
@@ -201,13 +200,13 @@ COPY --chown=payara:payara maven/supplements ${DEPLOY_DIR}/dataverse/supplements
 COPY --chown=payara:payara maven/maven-archiver ${DEPLOY_DIR}/maven-archiver/
 
 # Create symlinks for jHove
-RUN ln -s ${DEPLOY_DIR}/dataverse/supplements/jhove.conf ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/config/jhove.conf && \
-    ln -s ${DEPLOY_DIR}/dataverse/supplements/jhoveConfig.xsd ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/config/jhoveConfig.xsd && \
-    sed -i ${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/config/jhove.conf -e "s:/usr/local/payara5/glassfish/domains/domain1:${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}:g"
+RUN ln -s "${DEPLOY_DIR}/dataverse/supplements/jhove.conf" "${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/config/jhove.conf" && \
+    ln -s "${DEPLOY_DIR}/dataverse/supplements/jhoveConfig.xsd" "${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/config/jhoveConfig.xsd" && \
+    sed -i "${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}/config/jhove.conf" -e "s:/usr/local/payara5/glassfish/domains/domain1:${PAYARA_DIR}/glassfish/domains/${DOMAIN_NAME}:g"
 
 # Copy init and application scripts
 COPY --chown=payara:payara maven/scripts/app ${SCRIPT_DIR}/
-RUN chmod +x ${SCRIPT_DIR}/*
+RUN chmod +x "${SCRIPT_DIR}"/*
 
 # Set the entrypoint to tini (as a process supervisor)
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/conf/container/docker-run/secrets/doi_asadmin
+++ b/conf/container/docker-run/secrets/doi_asadmin
@@ -1,1 +1,0 @@
-AS_ADMIN_ALIASPASSWORD=changeme

--- a/conf/container/scripts/app/init_2_conf_payara.sh
+++ b/conf/container/scripts/app/init_2_conf_payara.sh
@@ -27,8 +27,9 @@ for alias in rserve doi
 do
   if [ -f "${SECRETS_DIR}"/$alias/password ]; then
     echo "INFO: Defining password alias for $alias"
-    sed -e "s#^#AS_ADMIN_ALIASPASSWORD=#" < "${SECRETS_DIR}"/$alias/password > "${SECRETS_DIR}"/${alias}_asadmin
-    echo "create-password-alias ${alias}_password_alias --passwordfile ${SECRETS_DIR}/${alias}_asadmin" >> "${DV_POSTBOOT}"
+    PASSTMP=$(mktemp)
+    sed -e "s#^#AS_ADMIN_ALIASPASSWORD=#" < "${SECRETS_DIR}"/$alias/password > "${PASSTMP}"
+    echo "create-password-alias ${alias}_password_alias --passwordfile ${PASSTMP}" >> "${DV_POSTBOOT}"
   else
     echo "WARNING: Could not find 'password' secret for ${alias} in ${SECRETS_DIR}. Check your Kubernetes Secrets and their mounting!"
   fi

--- a/conf/solr/Dockerfile
+++ b/conf/solr/Dockerfile
@@ -4,12 +4,17 @@
 # You may obtain a copy of the License at
 # http://www.apache.org/licenses/LICENSE-2.0
 
-FROM solr:@solr.version@
+# Retrieve target solr version from build arg
+ARG SOLR_VERSION
+
+FROM solr:$SOLR_VERSION
+# Repeat because of scope (https://docs.docker.com/engine/reference/builder/#scope)
+ARG SOLR_VERSION
 
 ENV SOLR_OPTS="-Dsolr.jetty.request.header.size=102400" \
     COLLECTION="collection1" \
     CONFIGSET="dataverse" \
-    CONFIGSETS_DIR=/opt/solr-@solr.version@/server/solr/configsets
+    CONFIGSETS_DIR="/opt/solr-${SOLR_VERSION}/server/solr/configsets"
 
 USER root
 # Create the Dataverse configset for Solr

--- a/doc/release-notes/8160-thumbnail-limit.md
+++ b/doc/release-notes/8160-thumbnail-limit.md
@@ -1,0 +1,1 @@
+New defaults have been added for when to create thumbnails for images and PDFs. The default is 3 MB for images, 1 MB for PDFs. Previously, there was no default.

--- a/doc/sphinx-guides/source/developers/tips.rst
+++ b/doc/sphinx-guides/source/developers/tips.rst
@@ -78,6 +78,17 @@ Netbeans Connector Chrome Extension
 
 For faster iteration while working on JSF pages, it is highly recommended that you install the Netbeans Connector Chrome Extension listed in the :doc:`tools` section. When you save XHTML or CSS files, you will see the changes immediately. Hipsters call this "hot reloading". :)
 
+Thumbnails
+----------
+
+In order for thumnails to be generated for PDFs, you need to install ImageMagick and configure Dataverse to use the ``convert`` binary.
+
+Assuming you're using Homebrew:
+
+``brew install imagemagick``
+
+Then configure the JVM option mentioned in :ref:`install-imagemagick` to the path to ``convert`` which for Homebrew is usually ``/usr/local/bin/convert``.
+
 Database Schema Exploration
 ---------------------------
 

--- a/doc/sphinx-guides/source/installation/config.rst
+++ b/doc/sphinx-guides/source/installation/config.rst
@@ -1146,12 +1146,12 @@ For overriding the default path to the ``convert`` binary from ImageMagick (``/u
 dataverse.dataAccess.thumbnail.image.limit
 ++++++++++++++++++++++++++++++++++++++++++
 
-For limiting the size (in bytes) of thumbnail images generated from files.
+For limiting the size (in bytes) of thumbnail images generated from files. The default is 3000000 bytes (3 MB).
 
 dataverse.dataAccess.thumbnail.pdf.limit
 ++++++++++++++++++++++++++++++++++++++++
 
-For limiting the size (in bytes) of thumbnail images generated from files.
+For limiting the size (in bytes) of thumbnail images generated from files. The default is 1000000 bytes (1 MB).
 
 .. _doi.baseurlstring:
 

--- a/doc/sphinx-guides/source/installation/prerequisites.rst
+++ b/doc/sphinx-guides/source/installation/prerequisites.rst
@@ -265,6 +265,8 @@ or you may install it manually::
         # chmod +x jq
         # jq --version
 
+.. _install-imagemagick:
+
 ImageMagick
 -----------
 
@@ -279,8 +281,6 @@ On a Red Hat or derivative Linux distribution, you can install ImageMagick with 
 
 (most RedHat systems will have it pre-installed).
 When installed using standard ``yum`` mechanism, above, the executable for the ImageMagick convert utility will be located at ``/usr/bin/convert``. No further configuration steps will then be required.
-
-On MacOS you can compile ImageMagick from sources, or use one of the popular installation frameworks, such as brew.
 
 If the installed location of the convert executable is different from ``/usr/bin/convert``, you will also need to specify it in your Payara configuration using the JVM option, below. For example::
 

--- a/pom.xml
+++ b/pom.xml
@@ -981,6 +981,13 @@
                 <ct.run.it>0</ct.run.it>
                 <ct.run.db.user>dataverse</ct.run.db.user>
                 <ct.run.db.pass>changeme</ct.run.db.pass>
+                <!--
+                    Note: Temporary workaround due to problems with Payara 5.2021.5
+                    Note: Remove when upstream is at 5.2021.8+
+                    See also: https://github.com/IQSS/dataverse/issues/8048
+                    See also: https://github.com/payara/Payara/issues/5368
+                -->
+                <payara.version>5.2021.8</payara.version>
             </properties>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <junit.version>4.13.1</junit.version>
         <junit.jupiter.version>5.7.0</junit.jupiter.version>
         <junit.vintage.version>${junit.jupiter.version}</junit.vintage.version>
-        <testcontainers.version>1.15.0</testcontainers.version>
+        <testcontainers.version>1.16.2</testcontainers.version>
         <microbean-mpconfig.version>0.4.1</microbean-mpconfig.version>
         <mockito.version>2.28.2</mockito.version>
         <flyway.version>5.2.4</flyway.version>
@@ -741,6 +741,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>solr</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1037,6 +1037,8 @@
                             </execution>
                         </executions>
                     </plugin>
+                    
+                    <!-- Build images via Docker Maven Plugin and provide option to run -->
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
@@ -1078,7 +1080,7 @@
                                         <env>
                                             <DATAVERSE_DB_USER>${ct.run.db.user}</DATAVERSE_DB_USER>
                                             <DATAVERSE_DB_PASSWORD>${ct.run.db.pass}</DATAVERSE_DB_PASSWORD>
-                                            <ENABLE_INTEGRATION_TESTS>${ct.run.it}}</ENABLE_INTEGRATION_TESTS>
+                                            <ENABLE_INTEGRATION_TESTS>${ct.run.it}</ENABLE_INTEGRATION_TESTS>
                                             <ENABLE_JDWP>${ct.run.jdwp}</ENABLE_JDWP>
                                             <ENABLE_JREBEL>${ct.run.jrebel}</ENABLE_JREBEL>
                                         </env>

--- a/pom.xml
+++ b/pom.xml
@@ -969,11 +969,11 @@
                 
                 <!--
                     Note: Temporary workaround due to problems with Payara 5.2021.5
-                    Note: Remove when upstream is at 5.2021.8+
+                    Note: Remove when upstream is at 5.2021.9+
                     See also: https://github.com/IQSS/dataverse/issues/8048
                     See also: https://github.com/payara/Payara/issues/5368
                 -->
-                <payara.version>5.2021.8</payara.version>
+                <payara.version>5.2021.9</payara.version>
             </properties>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1053,6 +1053,13 @@
                                     <build>
                                         <skip>${ct.build.app.skip}</skip>
                                         <dockerFile>${project.basedir}/conf/container/Dockerfile</dockerFile>
+                                        <args>
+                                            <!--
+                                                This can be made configurable by replacing with variables.
+                                                We could use different Java versions and/or distributions that way.
+                                            -->
+                                            <BASE_IMAGE>openjdk:11-jre</BASE_IMAGE>
+                                        </args>
                                         <filter>@</filter>
                                         <assembly>
                                             <mode>tar</mode>
@@ -1113,6 +1120,9 @@
                                     <build>
                                         <skip>${ct.build.solr.skip}</skip>
                                         <dockerFile>${project.basedir}/conf/solr/Dockerfile</dockerFile>
+                                        <args>
+                                            <SOLR_VERSION>${solr.version}</SOLR_VERSION>
+                                        </args>
                                         <filter>@</filter>
                                         <assembly>
                                             <mode>tar</mode>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <junit.jupiter.version>5.7.0</junit.jupiter.version>
         <junit.vintage.version>${junit.jupiter.version}</junit.vintage.version>
         <testcontainers.version>1.16.2</testcontainers.version>
-        <microbean-mpconfig.version>0.4.1</microbean-mpconfig.version>
+        <microbean-mpconfig.version>0.4.2</microbean-mpconfig.version>
         <mockito.version>2.28.2</mockito.version>
         <flyway.version>5.2.4</flyway.version>
         <jhove.version>1.20.1</jhove.version>
@@ -939,40 +939,11 @@
         <profile>
             <id>all-unit-tests</id>
         </profile>
-        <!-- TODO: Add a profile to run API tests (integration tests that end in IT.java. See conf/docker-aio/run-test-suite.sh -->
-        <profile>
-            <id>tc</id>
-            <properties>
-                <skipUnitTests>true</skipUnitTests>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.22.2</version>
-                        <configuration>
-                            <groups>testcontainers</groups>
-                            <systemPropertyVariables>
-                                <postgresql.server.version>${postgresql.server.version}</postgresql.server.version>
-                            </systemPropertyVariables>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>ct</id>
             <properties>
                 <skipUnitTests>true</skipUnitTests>
+                
                 <ct.build.registry>ghcr.io</ct.build.registry>
                 <ct.build.tag>${project.version}</ct.build.tag>
                 <ct.build.app.skip>false</ct.build.app.skip>
@@ -981,11 +952,21 @@
                 <ct.build.solr.skip>false</ct.build.solr.skip>
                 <ct.build.solr.tag>${ct.build.tag}</ct.build.solr.tag>
                 <ct.build.solr.name>gdcc/solr-k8s:${ct.build.solr.tag}</ct.build.solr.name>
+                
                 <ct.run.jdwp>1</ct.run.jdwp>
                 <ct.run.jrebel>0</ct.run.jrebel>
                 <ct.run.it>0</ct.run.it>
+                <ct.run.wait>90000</ct.run.wait>
                 <ct.run.db.user>dataverse</ct.run.db.user>
                 <ct.run.db.pass>changeme</ct.run.db.pass>
+                
+                <ct.run.dir>${project.basedir}/conf/container/docker-run</ct.run.dir>
+                <ct.run.envfile>${ct.run.dir}/env</ct.run.envfile>
+                <ct.run.dir.data>${ct.run.dir}/data</ct.run.dir.data>
+                <ct.run.dir.secrets>${ct.run.dir}/secrets</ct.run.dir.secrets>
+                <ct.run.mount.data>/data</ct.run.mount.data>
+                <ct.run.mount.secrets>/secrets</ct.run.mount.secrets>
+                
                 <!--
                     Note: Temporary workaround due to problems with Payara 5.2021.5
                     Note: Remove when upstream is at 5.2021.8+
@@ -1089,7 +1070,7 @@
                                             <ENABLE_JDWP>${ct.run.jdwp}</ENABLE_JDWP>
                                             <ENABLE_JREBEL>${ct.run.jrebel}</ENABLE_JREBEL>
                                         </env>
-                                        <envPropertyFile>${project.basedir}/conf/container/docker-run/env</envPropertyFile>
+                                        <envPropertyFile>${ct.run.envfile}</envPropertyFile>
                                         <hostname>dataverse</hostname>
                                         <ports>
                                             <!-- Usual HTTP access -->
@@ -1109,7 +1090,8 @@
                                         </dependsOn>
                                         <volumes>
                                             <bind>
-                                                <volume>${project.basedir}/conf/container/docker-run/secrets:/secrets</volume>
+                                                <volume>${ct.run.dir.secrets}:${ct.run.mount.secrets}</volume>
+                                                <!-- TODO: add tmpfs or volume mount for data directory to avoid storing in overlayfs -->
                                             </bind>
                                         </volumes>
                                         <wait>
@@ -1119,7 +1101,7 @@
                                                 <status>200..399</status>
                                             </http>
                                             <log>dataverse was successfully deployed</log>
-                                            <time>180000</time>
+                                            <time>${ct.run.wait}</time>
                                             <exec>
                                                 <postStart>/opt/payara/scripts/bootstrap-job.sh</postStart>
                                             </exec>
@@ -1150,6 +1132,7 @@
                                             <mode>custom</mode>
                                             <name>dataverse</name>
                                         </network>
+                                        <!-- TODO: add tmpfs or volume mount for data directory to avoid storing in overlayfs -->
                                     </run>
                                 </image>
                                 <!-- Postgresql Image (no build, run only) -->
@@ -1166,6 +1149,7 @@
                                             <POSTGRES_USER>${ct.run.db.user}</POSTGRES_USER>
                                             <POSTGRES_PASSWORD>${ct.run.db.pass}</POSTGRES_PASSWORD>
                                         </env>
+                                        <!-- TODO: add tmpfs or volume mount for data directory to avoid storing in overlayfs -->
                                     </run>
                                 </image>
                                 <!-- MailHog Fake SMTP Server (no build, run only) -->
@@ -1187,11 +1171,42 @@
                                             <mode>custom</mode>
                                             <name>dataverse</name>
                                         </network>
+                                        <!-- TODO: add tmpfs or volume mount for data directory to avoid storing in overlayfs -->
                                     </run>
                                 </image>
                             </images>
                             <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
                         </configuration>
+                    </plugin>
+                    
+                    <!-- Maven Failsafe based integration tests using Testcontainers -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                        <configuration>
+                            <groups>standard-api-test-set</groups>
+                            <systemPropertyVariables>
+                                <tc.enabled>true</tc.enabled>
+                                <postgresql.server.version>${postgresql.server.version}</postgresql.server.version>
+                                <solr.image>${ct.build.solr.name}</solr.image>
+                                <app.image>${ct.build.app.name}</app.image>
+                                <app.wait>${ct.run.wait}</app.wait>
+                                <app.envfile>${ct.run.envfile}</app.envfile>
+                                <app.dir.secrets>${ct.run.dir.secrets}</app.dir.secrets>
+                                <app.dir.data>${ct.run.dir.data}</app.dir.data>
+                                <app.mount.secrets>${ct.run.mount.secrets}</app.mount.secrets>
+                                <app.mount.data>${ct.run.mount.data}</app.mount.data>
+                            </systemPropertyVariables>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
+++ b/src/main/java/edu/harvard/iq/dataverse/DataversePage.java
@@ -613,6 +613,7 @@ public class DataversePage implements java.io.Serializable {
                         // so we skip looking at parents (which get set automatically with their children)
                         if (!dsft.isHasChildren() && dsft.isRequiredDV()) {
                             boolean addRequiredInputLevels = false;
+                            boolean parentAlreadyAdded = false;
                             
                             if (!dsft.isHasParent() && dsft.isInclude()) {
                                 addRequiredInputLevels = !dsft.isRequired();
@@ -624,9 +625,21 @@ public class DataversePage implements java.io.Serializable {
                             if (addRequiredInputLevels) {
                                 listDFTIL.add(new DataverseFieldTypeInputLevel(dsft, dataverse,true, true));
                             
-                                //also add the parent as required
+                                //also add the parent as required (if it hasn't been added already)
+                                // todo: review needed .equals() methods, then change this to use a Set, in order to simplify code
                                 if (dsft.isHasParent()) {
-                                    listDFTIL.add(new DataverseFieldTypeInputLevel(dsft.getParentDatasetFieldType(), dataverse,true, true));
+                                    DataverseFieldTypeInputLevel parentToAdd = new DataverseFieldTypeInputLevel(dsft.getParentDatasetFieldType(), dataverse, true, true);
+                                    for (DataverseFieldTypeInputLevel dataverseFieldTypeInputLevel : listDFTIL) {
+                                        if (dataverseFieldTypeInputLevel.getDatasetFieldType().getId() == parentToAdd.getDatasetFieldType().getId()) {
+                                            parentAlreadyAdded = true;
+                                            break;
+                                        }
+                                    }
+                                    if (!parentAlreadyAdded) {
+                                        // Only add the parent once. There's a UNIQUE (dataverse_id, datasetfieldtype_id)
+                                        // constraint on the dataversefieldtypeinputlevel table we need to avoid.
+                                        listDFTIL.add(parentToAdd);
+                                    }
                                 }      
                             }
                         }

--- a/src/main/java/edu/harvard/iq/dataverse/dataaccess/ImageThumbConverter.java
+++ b/src/main/java/edu/harvard/iq/dataverse/dataaccess/ImageThumbConverter.java
@@ -36,6 +36,7 @@ import javax.imageio.stream.ImageOutputStream;
 
 import edu.harvard.iq.dataverse.DataFile;
 import edu.harvard.iq.dataverse.util.FileUtil;
+import edu.harvard.iq.dataverse.util.SystemConfig;
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -176,7 +177,7 @@ public class ImageThumbConverter {
 
     private static boolean generatePDFThumbnail(StorageIO<DataFile> storageIO, int size) {
         if (isPdfFileOverSizeLimit(storageIO.getDataFile().getFilesize())) {
-            logger.fine("Image file too large (" + storageIO.getDataFile().getFilesize() + " bytes) - skipping");
+            logger.fine("PDF file too large (" + storageIO.getDataFile().getFilesize() + " bytes) - skipping");
             return false;
         }
 
@@ -925,27 +926,7 @@ public class ImageThumbConverter {
     }
 
     private static long getThumbnailSizeLimit(String type) {
-        String option = null;
-        if ("Image".equals(type)) {
-            option = System.getProperty("dataverse.dataAccess.thumbnail.image.limit");
-        } else if ("PDF".equals(type)) {
-            option = System.getProperty("dataverse.dataAccess.thumbnail.pdf.limit");
-        }
-        Long limit = null;
-
-        if (option != null && !option.equals("")) {
-            try {
-                limit = new Long(option);
-            } catch (NumberFormatException nfe) {
-                limit = null;
-            }
-        }
-
-        if (limit != null) {
-            return limit.longValue();
-        }
-
-        return 0;
+        return SystemConfig.getThumbnailSizeLimit(type);
     }
 
     private static boolean isImageMagickInstalled() {

--- a/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/settings/SettingsServiceBean.java
@@ -212,12 +212,6 @@ public class SettingsServiceBean {
         /* the number of files the GUI user is allowed to upload in one batch, 
             via drag-and-drop, or through the file select dialog */
         MultipleUploadFilesLimit,
-        /* Size limits for generating thumbnails on the fly */
-        /* (i.e., we'll attempt to generate a thumbnail on the fly if the 
-         * size of the file is less than this)
-        */
-        ThumbnailSizeLimitImage,
-        ThumbnailSizeLimitPDF,
         /* return email address for system emails such as notifications */
         SystemEmail, 
         /* size limit for Tabular data file ingests */

--- a/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
+++ b/src/main/java/edu/harvard/iq/dataverse/util/SystemConfig.java
@@ -123,6 +123,8 @@ public class SystemConfig {
     private static final String JVM_TIMER_SERVER_OPTION = "dataverse.timerServer";
     
     private static final long DEFAULT_GUESTBOOK_RESPONSES_DISPLAY_LIMIT = 5000L; 
+    private static final long DEFAULT_THUMBNAIL_SIZE_LIMIT_IMAGE = 3000000L; // 3 MB
+    private static final long DEFAULT_THUMBNAIL_SIZE_LIMIT_PDF = 1000000L; // 1 MB
     
     public final static String DEFAULTCURATIONLABELSET = "DEFAULT";
     public final static String CURATIONLABELSDISABLED = "DISABLED";
@@ -493,29 +495,28 @@ public class SystemConfig {
         return 500000;
     }
 
-    // TODO: (?)
-    // create sensible defaults for these things? -- 4.2.2
     public long getThumbnailSizeLimitImage() {
-        long limit = getThumbnailSizeLimit("Image");
-        return limit == 0 ? 500000 : limit;
-    } 
-    
-    public long getThumbnailSizeLimitPDF() {
-        long limit = getThumbnailSizeLimit("PDF");
-        return limit == 0 ? 500000 : limit;
+        return getThumbnailSizeLimit("Image");
     }
-    
-    public long getThumbnailSizeLimit(String type) {
+
+    public long getThumbnailSizeLimitPDF() {
+        return getThumbnailSizeLimit("PDF");
+    }
+
+    public static long getThumbnailSizeLimit(String type) {
         String option = null; 
         
         //get options via jvm options
         
         if ("Image".equals(type)) {
             option = System.getProperty("dataverse.dataAccess.thumbnail.image.limit");
+            return getLongLimitFromStringOrDefault(option, DEFAULT_THUMBNAIL_SIZE_LIMIT_IMAGE);
         } else if ("PDF".equals(type)) {
             option = System.getProperty("dataverse.dataAccess.thumbnail.pdf.limit");
+            return getLongLimitFromStringOrDefault(option, DEFAULT_THUMBNAIL_SIZE_LIMIT_PDF);
         }
 
+        // Zero (0) means no limit.
         return getLongLimitFromStringOrDefault(option, 0L);
     }
     

--- a/src/test/java/edu/harvard/iq/dataverse/api/IndexIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/IndexIT.java
@@ -32,10 +32,6 @@ public class IndexIT {
         makeSureTokenlessSearchIsEnabled.then().assertThat()
                 .statusCode(OK.getStatusCode());
 
-        Response remove = UtilIT.deleteSetting(SettingsServiceBean.Key.ThumbnailSizeLimitImage);
-        remove.then().assertThat()
-                .statusCode(200);
-
     }
 
   

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -50,10 +50,6 @@ public class SearchIT {
         makeSureTokenlessSearchIsEnabled.then().assertThat()
                 .statusCode(OK.getStatusCode());
 
-        Response remove = UtilIT.deleteSetting(SettingsServiceBean.Key.ThumbnailSizeLimitImage);
-        remove.then().assertThat()
-                .statusCode(200);
-
     }
 
     @Test

--- a/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
+++ b/src/test/java/edu/harvard/iq/dataverse/util/SystemConfigTest.java
@@ -47,4 +47,12 @@ class SystemConfigTest {
         int actualResult = SystemConfig.getIntLimitFromStringOrDefault(inputString, 5);
         assertEquals(expectedResult, actualResult);
     }
+
+    @Test
+    void testGetThumbnailSizeLimit() {
+        assertEquals(3000000l, SystemConfig.getThumbnailSizeLimit("Image"));
+        assertEquals(1000000l, SystemConfig.getThumbnailSizeLimit("PDF"));
+        assertEquals(0l, SystemConfig.getThumbnailSizeLimit("NoSuchType"));
+    }
+
 }


### PR DESCRIPTION
- Optimize Dockerfiles
- Remove "tc" Maven profile and merge with "ct" profile
- Make "ct" Profile override the Payara version with 5.2021.8/9 to work around #8048
- Add necessary bits to make containers integration testing ready (publish root, ...)
- Redact superuser API token from log but make it usable within the bootstrapping script